### PR TITLE
Restrict access to login and Register routes for authenticated users

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,8 +21,8 @@ import BreathingGame from "./components/Pages/Breathing.jsx";
 
 const routeDefinitions = [
   { path: "/", element: <Home /> },
-  { path: "/login", element: <LoginForm /> },
-  { path: "/register", element: <SignupForm /> },
+  { path: "/login", element: <AuthenticatedRoute element={<LoginForm />} /> },
+  { path: "/register", element: <AuthenticatedRoute element={<SignupForm />} /> },
   { path: "/mood", element: <AuthenticatedRoute element={<MoodLogger />} /> },
   { path: "/sleep", element: <AuthenticatedRoute element={<SleepTracker />} /> },
   { path: "/joke", element: <AuthenticatedRoute element={<JokeGenerator />} /> },

--- a/frontend/src/utils/useAuthContext.jsx
+++ b/frontend/src/utils/useAuthContext.jsx
@@ -1,9 +1,17 @@
 import { Navigate } from "react-router-dom";
 import { useAuth } from "./authProvider";
+import LoginForm from "../components/Pages/Login.jsx";
+import SignupForm from "../components/Pages/Signup.jsx";
 
 const AuthenticatedRoute = ({ element }) => {
   const { token } = useAuth();
 
+  if (token && (element.type === LoginForm || element.type === SignupForm)) {
+    return <Navigate to="/" />;
+  }
+  if (!token && (element.type === LoginForm || element.type === SignupForm)) {
+    return element; // Render login form if no token
+  }
   if (token) {
     return element; // If token exists, render the requested component
   } else {


### PR DESCRIPTION
Fixes #47

This PR implements authentication checks for the login and Register routes to prevent access by already authenticated users. When a user is already logged in, attempting to access the login or Register routes will redirect them to the root route.

Changes:
- Modified the AuthenticatedRoute component to check if the user is already logged in and redirect them to the root route if they try to access the login or Register routes.
- Imported the LoginForm and RegisterForm components in the useAuthContext.jsx file to enable the authentication checks.
- Updated the AuthenticatedRoute component to handle the Register route in addition to the login route